### PR TITLE
Correction nom répertoire JS manquant

### DIFF
--- a/index.html
+++ b/index.html
@@ -430,7 +430,6 @@
 -->
 
 <!-- Included JS Files (Compressed) -->
-<script src="javascripts/jquery.js"></script>
 <script src="javascripts/foundation.min.js"></script>
 <script src="javascripts/jquery-ui-1.9.2.custom.min.js"></script>
 <script src="javascripts/jquery-ui.touchpouch.js"></script>


### PR DESCRIPTION
Pour définitivement activer la compatibilité iPad :)
- jQuery qui était chargé en double (déja présent dans foundation)
